### PR TITLE
Update image to use JDK 21

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea/
+.DS_Store

--- a/chrome-dependencies.txt
+++ b/chrome-dependencies.txt
@@ -1,0 +1,37 @@
+# Source: https://source.chromium.org/chromium/chromium/src/+/main:chrome/installer/linux/debian/dist_package_versions.json
+# Keep the list sorted.
+libasound2t64
+libatk-bridge2.0-0t64
+libatk1.0-0t64
+libatspi2.0-0t64
+libc6
+libcairo2
+libcups2t64
+libdbus-1-3
+libdrm2
+libexpat1
+libgbm1
+libglib2.0-0t64
+libnspr4
+libnss3
+libpango-1.0-0
+libpangocairo-1.0-0
+libstdc++6
+libudev1
+libuuid1
+libx11-6
+libx11-xcb1
+libxcb-dri3-0
+libxcb1
+libxcomposite1
+libxcursor1
+libxdamage1
+libxext6
+libxfixes3
+libxi6
+libxkbcommon0
+libxrandr2
+libxrender1
+libxshmfence1
+libxss1
+libxtst6


### PR DESCRIPTION
- Use `eclipse-temurin:21` as the base image
- Move chrome dependencies to a separate file
- Adapt dependencies for Ubuntu 24.04
- Don't install node and npm, as Kotlin doesn't use then and installs them on its own