### PR TITLE
Install Rust and Cargo using rustup for `ktor-client-webrtc-rs`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,4 +28,7 @@ RUN <<EOT bash
     temurin-8-jdk
   apt-get clean
   rm -rf /var/lib/apt/lists/* /tmp/chrome-dependencies.txt
+
+  # Install Rust and Cargo using rustup for `ktor-client-webrtc-rs`
+  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
 EOT


### PR DESCRIPTION
Fix the CI issue for `ktor-client-webrtc-rs` with a missing Rust toolchain.

- https://github.com/ktorio/ktor/pull/5044
- [Failing TeamCity Build](https://ktor.teamcity.com/buildConfiguration/Ktor_KtorMatrixWasmJsChromeNodeJs/358011)